### PR TITLE
ISSUE=9232 IPv6 balancing as a single block

### DIFF
--- a/SciPass.spec
+++ b/SciPass.spec
@@ -8,6 +8,8 @@ URL: http://globalnoc.iu.edu
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires: ryu
+Requires: perl-Term-ReadLine-Gnu
+
 
 %description
 SciPass is a Science DMZ and IDS load balance via OpenFlow and Ryu

--- a/python/SimpleBalancer.py
+++ b/python/SimpleBalancer.py
@@ -307,33 +307,20 @@ class SimpleBalancer:
     """used to register a handler for del prefix events"""
     self.movePrefixHandlers.append(handler)
 
-  def fireAddPrefix(self,sensor,prefix):
+  def fireAddPrefix(self,group,prefix):
     """When called will fire each of the registered add prefix handlers"""
     for handler in self.addPrefixHandlers:
-      handler(sensor,prefix)
+      handler(group,prefix)
 
-  def fireDelPrefix(self,sensor,prefix):
+  def fireDelPrefix(self,group,prefix):
     """When called will fire each of the registered del prefix handlers"""
     for handler in self.delPrefixHandlers:
-      handler(sensor,prefix)
+      handler(group,prefix)
 
-  def fireMovePrefix(self,oldSensor,newSensor,prefix):
+  def fireMovePrefix(self,oldGroup,newGroup,prefix):
     """when called will fire each of the registered move prefix handlers"""
     for handler in self.movePrefixHandlers:
-      handler(oldSensor,newSensor,prefix)
-
-  def setSensorPrefixList(self,sensor,prefixList):
-    """update the sensor's prefix list"""
-    if(len(prefixList) >self.maxPrefixes):
-        raise MaxPrefixesError(str(prefixList))
-
-    #--- reset the list
-    del self.sensorPrefixes[sensor][:]
-
-    for prefix in prefixList:
-        self.addSensorPrefix(sensor,prefix)
-
-    return 1
+      handler(oldGroup,newGroup,prefix)
 
 
   def delGroupPrefix(self,group,targetPrefix):

--- a/python/t/SciPassTest.py
+++ b/python/t/SciPassTest.py
@@ -43,13 +43,20 @@ class TestInit(unittest.TestCase):
         #first setup the handler to get all the flows that were sent
         flows = []
         def flowSent(dpid = None, header = None, actions = None,command = None, priority = None, idle_timeout = None, hard_timeout = None):
-            flows.append({'dpid': dpid, 'header': header, 'actions': actions, 'command': command, 'priority': priority, 'idle_timeout': idle_timeout, 'hard_timeout': hard_timeout})
+            obj = {'dpid': dpid, 'header': header,
+                   'actions': actions, 'command': command,
+                   'priority': priority, 
+                   'idle_timeout': idle_timeout,
+                   'hard_timeout': hard_timeout}
+            flows.append(obj)
+            logging.error(obj)
+            
 
         api.registerForwardingStateChangeHandler(flowSent)
         datapath = Mock(id=1)
         api.switchJoined(datapath)
 
-        self.assertTrue( len(flows) == 33)
+        self.assertTrue( len(flows) == 37)
         #verify all of the 'flow details are set properly'
         for flow in flows:
             self.assertEquals(flow['dpid'], "%016x" % datapath.id)
@@ -107,57 +114,86 @@ class TestInit(unittest.TestCase):
         self.assertEquals(flow['header'], {'phys_port':2, 'nw_src': 167777280, 'nw_src_mask': 24})
         self.assertEquals(flow['priority'], 10)
         flow = flows[10]
+        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 2}])
+        self.assertEquals(flow['command'],"ADD")
+        self.assertEquals(flow['header'], {'dl_type': 34525, 'phys_port': 5})
+        self.assertEquals(flow['priority'], 10)
+        flow = flows[11]
+        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 5}])
+        self.assertEquals(flow['command'],"ADD")
+        self.assertEquals(flow['header'], {'dl_type': 34525, 'phys_port': 2})
+        self.assertEquals(flow['priority'], 10)
+        flow = flows[12]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': 1}, {'type': 'output', 'port': 2}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 5, 'dl_type': None})
         self.assertEquals(flow['priority'], 3)
-        flow = flows[11]
+        flow = flows[13]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': 10}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 6, 'dl_type': None})
         self.assertEquals(flow['priority'], 10)
-        flow = flows[12]
+        flow = flows[14]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': 6}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 10, 'dl_type': None})
         self.assertEquals(flow['priority'], 10)
-        flow = flows[13]
+        flow = flows[15]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': '27'}, {'type': 'output', 'port': '26'}, {'type': 'output', 'port': '5'}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 1, 'nw_src': 167776512, 'nw_src_mask': 24})
         self.assertEquals(flow['priority'], 500)
-        flow = flows[14]
+        flow = flows[16]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': '27'}, {'type': 'output', 'port': '26'}, {'type': 'output', 'port': '6'}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 10, 'nw_dst': 167776512, 'nw_dst_mask': 24})
         self.assertEquals(flow['priority'], 500)
-        flow = flows[15]
+        flow = flows[17]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
         self.assertEquals(flow['header'], {'phys_port': 1, 'nw_src': 167776512, 'nw_src_mask': 24})
         self.assertEquals(flow['priority'], 500)
-        flow = flows[16]
+        flow = flows[18]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
         self.assertEquals(flow['header'], {'phys_port': 10, 'nw_dst': 167776512, 'nw_dst_mask': 24})
         self.assertEquals(flow['priority'], 500)
-        flow = flows[17]
+        flow = flows[19]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': '21'}, {'type': 'output', 'port': '20'}, {'type': 'output', 'port': '5'}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 1, 'nw_src': 167776512, 'nw_src_mask': 24})
         self.assertEquals(flow['priority'], 500)
-        flow = flows[18]
+        flow = flows[20]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': '21'}, {'type': 'output', 'port': '20'}, {'type': 'output', 'port': '6'}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 10, 'nw_dst': 167776512, 'nw_dst_mask': 24})
         self.assertEquals(flow['priority'], 500)
-        flow = flows[19]
+        flow = flows[21]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': '27'}, {'type': 'output', 'port': '26'}, {'type': 'output', 'port': '5'}])
         self.assertEquals(flow['command'],"ADD")
         self.assertEquals(flow['header'], {'phys_port': 1, 'nw_src': 167776768, 'nw_src_mask': 24})
         self.assertEquals(flow['priority'], 500)
-        flow = flows[20]
+        flow = flows[22]
+#        logging.error(flows[21])
+#        pprint.pprint(flows[21])
+#        pprint.pprint(flows[22])
+#        pprint.pprint(flows[23])
+#        pprint.pprint(flows[24])
+#        pprint.pprint(flows[25])
+#        pprint.pprint(flows[26])
+#        pprint.pprint(flows[27])
+#        pprint.pprint(flows[28])
+#        pprint.pprint(flows[29])
+#        pprint.pprint(flows[30])
+#        pprint.pprint(flows[31])
+#        pprint.pprint(flows[32])
+#        pprint.pprint(flows[33])
+#        pprint.pprint(flows[34])
+#        pprint.pprint(flows[35])
+#        pprint.pprint(flows[36])
+#        pprint.pprint(flows[37])
 
+        
 class TestFunctionality(unittest.TestCase):
     def setUp(self):
         self.api = SciPass( logger = logging.getLogger(__name__),
@@ -173,7 +209,7 @@ class TestFunctionality(unittest.TestCase):
         datapath = Mock(id=1)
         self.api.switchJoined(datapath)
 
-        self.assertEquals( len(flows), 33)
+        self.assertEquals( len(flows), 37)
         self.api.updatePrefixBW("%016x" % datapath.id, ipaddr.IPv4Network("10.0.19.0/24"), 500,500)
         self.assertTrue(self.api.getBalancer("%016x" % datapath.id, "R&E").getPrefixBW(ipaddr.IPv4Network("10.0.19.0/24")), 1000)
         self.api.updatePrefixBW("%016x" % datapath.id, ipaddr.IPv4Network("10.0.17.0/24"), 500,500)
@@ -189,7 +225,7 @@ class TestFunctionality(unittest.TestCase):
         datapath = Mock(id=1)
         self.api.switchJoined(datapath)
         #self.logger.error("testing good flow")
-        self.assertEquals(len(flows),33)
+        self.assertEquals(len(flows),37)
         flows = []
         self.api.good_flow({"nw_src": "10.0.20.2/32", "nw_dst":"156.56.6.1/32", "tp_src":1, "tp_dst":2})
         self.assertEquals(len(flows),2)
@@ -221,7 +257,7 @@ class TestFunctionality(unittest.TestCase):
         datapath = Mock(id=1)
         self.api.switchJoined(datapath)
         #self.logger.error("testing good flow")
-        self.assertEquals(len(flows),33)
+        self.assertEquals(len(flows),37)
         flows = []
         self.api.bad_flow({"nw_src": "10.0.20.2/32", "nw_dst":"156.56.6.1/32", "tp_src":1, "tp_dst":2})
         self.assertEquals(len(flows),2)

--- a/python/t/etc/SciPass.xml
+++ b/python/t/etc/SciPass.xml
@@ -13,6 +13,7 @@
       <port of_port_id="2" type="lan" name="foo12" description="another lan int">
 	<prefix type="v4">10.0.19.0/24</prefix>
         <prefix type="v4">10.0.20.0/24</prefix>
+	<prefix type="v6">::/128</prefix>
       </port>
       
 


### PR DESCRIPTION
Because OF 1.0 doesn't support matching on IPv6 we treat IPv6 as a single indivisible block and match just on the ethernet type this will allow us to include it in our balancing.
