### PR TITLE
added SimpleBalancer mode and improved Balancing algorithm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=SciPass
-VERSION=1.0.1
+VERSION=1.0.2
 
 rpm:	dist
 	rpmbuild -ta dist/$(NAME)-$(VERSION).tar.gz

--- a/SciPass.spec
+++ b/SciPass.spec
@@ -1,6 +1,6 @@
 Summary: Science DMZ and IDS loadbalancer via OpenFlow RYU
 Name: SciPass
-Version: 1.0.1
+Version: 1.0.2
 Release: 1
 License: Apache2
 Group: GRNOC

--- a/SciPass.spec
+++ b/SciPass.spec
@@ -50,7 +50,7 @@ rm -rf $RPM_BUILD_ROOT
 %{python_sitelib}/SciPass/*
 %{perl_vendorlib}/*
 
-%defattr(754, root, root, -)
+%defattr(755, root, root, -)
 /usr/bin/scipass-cli.pl
 
 %doc

--- a/python/Ryu.py
+++ b/python/Ryu.py
@@ -336,7 +336,7 @@ class Ryu(app_manager.RyuApp):
 
     def _balance_loop(self):
          while 1:
-             self.logger.error("here!!")
+             self.logger.debug("Balancing")
              #--- tell the system to rebalance
              self.api.run_balancers()
              #--- sleep
@@ -452,8 +452,8 @@ class Ryu(app_manager.RyuApp):
         
            
     def process_flow_stats(self, stats, dp):
-        self.logger.error("flow stat processor")
-        self.logger.error("flows stats: " + str(len(stats)))
+        self.logger.debug("flow stat processor")
+        self.logger.debug("flows stats: " + str(len(stats)))
         #--- figure out the time since last stats
         prefix_bps = defaultdict(lambda: defaultdict(int))
         prefix_bytes = {}
@@ -569,7 +569,7 @@ class Ryu(app_manager.RyuApp):
                 try:
                     rate = bytes / float(int(stats_et))
                 except ZeroDivisionError:
-                    self.logger.error("Division by zero, rate = 0")
+                    self.logger.debug("Division by zero, rate = 0")
                     rate = 0
             
                 prefix_bps[prefix][dir] = rate

--- a/python/SciPass.py
+++ b/python/SciPass.py
@@ -404,8 +404,8 @@ class SciPass:
       for domain_name in self.config[dpid]:
           domain = self.config[dpid][domain_name]
           # loop through sensors
-          for group in domain.get('sensor_port_groups'):
-            sensors = domain.get('sensor_port_groups')[group];
+          for group in domain.get('sensor_groups'):
+            sensors = domain.get('sensor_groups')[group];
             for sensor in sensors:
               # return sensor info if we've found our port
               if(str(sensor.get('of_port_id')) == str(port_id)):
@@ -639,6 +639,7 @@ class SciPass:
                                               priority     = int(priority / 2))
 
       for prefix in in_port['prefixes']:
+        self.config[dpid][domain_name]['balancer'].addPrefix(prefix['prefix'])
         prefixes.append(prefix['prefix'])
         #specific prefix forwarding rules
         #FW LAN to specific LAN PORT
@@ -732,7 +733,8 @@ class SciPass:
                                             priority     = int(priority))
 
     #ok now that we have that done... start balancing!!!
-    self.config[dpid][domain_name]['balancer'].distributePrefixes(prefixes)
+    self.logger.info("Distributing Prefixes!")
+    self.config[dpid][domain_name]['balancer'].pushToSwitch()
     
 
   def _setupInlineIDS(self, dpid = None, domain_name = None):
@@ -746,6 +748,7 @@ class SciPass:
     in_port = ports['lan'][0]
 
     for prefix in in_port['prefixes']:
+      self.config[dpid][domain_name]['balancer'].addPrefix(prefix['prefix'])
       prefixes.append(prefix['prefix'])
 
     #LAN to WAN
@@ -781,7 +784,8 @@ class SciPass:
                                             priority     = int(priority / 3))
 
     #ok now that we have that done... start balancing!!!
-    self.config[dpid][domain_name]['balancer'].distributePrefixes(prefixes)
+    self.logger.info("Distributing Prefixes!")
+    self.config[dpid][domain_name]['balancer'].pushToSwitch()
 
   def _setupBalancer(self, dpid = None, domain_name = None):
     self.logger.debug("balancer rule init")
@@ -791,9 +795,11 @@ class SciPass:
     for port in ports['lan']:
       in_port = port
       for prefix in in_port['prefixes']:
+        self.config[dpid][domain_name]['balancer'].addPrefix(prefix['prefix'])
         prefixes.append(prefix['prefix'])
 
-    self.config[dpid][domain_name]['balancer'].distributePrefixes(set(prefixes))
+    self.logger.info("Distributing Prefixes!")
+    self.config[dpid][domain_name]['balancer'].pushToSwitch()
         
   def addPrefix(self, dpid=None, domain_name=None, group_id=None, prefix=None, priority=None):
     #self.logger.error("Add Prefix " + str(domain_name) + " " + str(group_id) + " " + str(prefix))

--- a/python/SimpleBalancer.py
+++ b/python/SimpleBalancer.py
@@ -88,6 +88,8 @@ class SimpleBalancer:
       self.delPrefixHandlers  = []
       self.movePrefixHandlers = []
       
+      self.prefix_list = []
+      self.initialized = False
       return
   
   def __str__(self):
@@ -98,6 +100,19 @@ class SimpleBalancer:
  #     res = res + "  PrefixBW: "+str(self.prefixBW) +"\n"
  #     res = res + "  pre2sensor: "+str(self.prefixSensor)+"\n"
       return res 
+
+  def addPrefix(self, prefix):
+      if(prefix not in self.prefix_list):
+          self.prefix_list.append(prefix)
+
+  def pushToSwitch(self):
+      """initialize a device"""
+      if(self.initialized):
+          self.pushAllPrefixes()
+      else:
+          self.distributePrefixes(self.prefix_list)
+          self.initialized = True
+      self.logger.info("Switch Initialized")
 
   def getConfig(self):
       obj = {}
@@ -123,8 +138,6 @@ class SimpleBalancer:
       for pfix in self.prefixPriorities:
           if(pfix.Contains(prefix)):
               return self.prefixPriorities[pfix]
-
-
 
   def showStatus(self):
       """returns text represention in show format of the current status balancing"""
@@ -176,7 +189,7 @@ class SimpleBalancer:
   #distributes prefixes through all groups
   #this is not going to be event but it is at least a start
   def distributePrefixes(self, prefix_array):
-      self.logger.info("Distributing prefixes")
+      self.logger.debug("Distributing prefixes: " + str(prefix_array))
 
       group_index = 0
       for prefix in prefix_array:
@@ -354,7 +367,7 @@ class SimpleBalancer:
     if(self.prefixBW.has_key(prefix)):
         self.prefixBW[prefix] = (bwTx * 8) + (bwRx * 8)
         return 1
-    self.logger.error( "Error updating prefixBW for " + str(prefix) + "... prefix does not exist")
+    self.logger.debug( "Error updating prefixBW for " + str(prefix) + "... prefix does not exist")
     return 0
 
   def registerAddPrefixHandler(self,handler):
@@ -473,7 +486,7 @@ class SimpleBalancer:
       try:
           subnets = self.splitPrefix(candidatePrefix)
           bw = self.prefixBW[candidatePrefix]
-          self.logger.error( "split prefix "+str(candidatePrefix) +" bw "+str((bw / 1000 / 1000 )) + "Mbps")
+          self.logger.info( "split prefix "+str(candidatePrefix) +" bw "+str((bw / 1000 / 1000 )) + "Mbps")
           #--- update the bandwidth we are guessing is going to each prefix to smooth things, before real data is avail
           self.prefixBW[candidatePrefix] = 0
           priority = self.getPrefixPriority(candidatePrefix)
@@ -517,7 +530,7 @@ class SimpleBalancer:
 
   def splitPrefix(self,prefix):
     """takes a prefix and splits it into 2 subnets that by increasing masklen by 1 bit"""
-    self.logger.error("Most Specific: " + str(self.mostSpecificPrefixLen))
+    self.logger.debug("Most Specific: " + str(self.mostSpecificPrefixLen))
     if(prefix.prefixlen <= int(self.mostSpecificPrefixLen) - 1):
         return prefix.Subnet()
     else:
@@ -585,12 +598,12 @@ class SimpleBalancer:
       totalHosts = totalHosts +  prefix.numhosts
       totalBW    = totalBW    +  self.prefixBW[prefix]
 
-    self.logger.error("Total BW for group = %s" % totalBW)
+    self.logger.debug("Total BW for group = %s" % totalBW)
 
     if(self.ignorePrefixBW == 0):
       #--- use prefix bandwidth to estimate load
       targetBW     = self.prefixBW[targetPrefix]
-      self.logger.error("targetBW: %s" % targetBW)
+      self.logger.debug("targetBW: %s" % targetBW)
       if(totalBW > 0 and targetBW > 0):
         percentTotal = targetBW / (totalBW * 1.0)
       else:
@@ -667,11 +680,11 @@ class SimpleBalancer:
     for group in self.groups:
       # don't include disabled sensors
       if(not self.getGroupStatus(group)): continue
-      self.logger.error("Group: " + str(group))
-      self.logger.error("Group Prefixes: {0}".format(self.groups[group]['prefixes']))
+      self.logger.debug("Group: " + str(group))
+      self.logger.debug("Group Prefixes: {0}".format(self.groups[group]['prefixes']))
       for prefix in self.groups[group]['prefixes']:
         #--- figure out total amount of traffic going over each sensor
-          self.logger.error("Prefix: " + str(prefix) + " BW: " + str((prefixBW[prefix]/1000/1000)) + "Mbps")
+          self.logger.debug("Prefix: " + str(prefix) + " BW: " + str((prefixBW[prefix]/1000/1000)) + "Mbps")
           totalBW  = totalBW + prefixBW[prefix]
           groupBW[group] = groupBW[group] + prefixBW[prefix]
       self.groups[group]['bandwidth'] = groupBW[group]
@@ -680,14 +693,14 @@ class SimpleBalancer:
       # don't include disabled sensors
       if(not self.getGroupStatus(group)): continue
 
-      self.logger.error("Group: " + str(group) + " bw " + str((groupBW[group]/1000/1000)) + "Mbps")
+      self.logger.debug("Group: " + str(group) + " bw " + str((groupBW[group]/1000/1000)) + "Mbps")
 
       if(totalBW > 0):
         load =groupBW[group] / float(totalBW)
       else:
         load = 0
 
-      self.logger.error("Group: " + str(group) + " load "+ str(load))
+      self.logger.debug("Group: " + str(group) + " load "+ str(load))
 
       if(load > maxLoad):
         maxLoad = load
@@ -701,9 +714,9 @@ class SimpleBalancer:
 
     #---
    
-    self.logger.error("max sensor = '"+str(maxGroup)+"' load "+str(maxLoad))
-    self.logger.error("loadminthreshold = " + str(self.sensorLoadMinThreshold))
-    self.logger.error("load delta = "+str(loadDelta)+" max "+str(maxGroup)+" min "+str(minGroup))
+    self.logger.debug("max sensor = '"+str(maxGroup)+"' load "+str(maxLoad))
+    self.logger.debug("loadminthreshold = " + str(self.sensorLoadMinThreshold))
+    self.logger.debug("load delta = "+str(loadDelta)+" max "+str(maxGroup)+" min "+str(minGroup))
 
     if( maxLoad >= self.sensorLoadMinThreshold ):
       if(loadDelta >= self.sensorLoadDeltaThreshold):
@@ -729,7 +742,7 @@ class SimpleBalancer:
         for candidatePrefix in sorted(tmpDict,key=tmpDict.get,reverse=True):
           if(self.splitSensorPrefix(maxGroup,candidatePrefix)):
               #--- success
-              self.logger.error("Sensor prefix successfully split")
+              self.logger.info("Sensor prefix successfully split")
               break
           else:
               self.logger.error("Sensor prefix not successfully split")

--- a/python/t/BalancerOnlyTest.py
+++ b/python/t/BalancerOnlyTest.py
@@ -8,6 +8,7 @@ import ipaddr
 import os
 from SciPass import SciPass
 import libxml2
+import time
 import xmlrunner
 
 
@@ -147,83 +148,60 @@ class BalancerInitTest(unittest.TestCase):
         #without network traffic there is nothing to balance!
         self.assertTrue( len(flows) == 0)
 
-        
-
         self.api.updatePrefixBW("0000000000000001", ipaddr.IPv4Network("129.79.0.0/16"), 2000000000, 0)
         self.api.updatePrefixBW("0000000000000001", ipaddr.IPv4Network("134.68.0.0/16"), 8000000000, 0)
         self.api.updatePrefixBW("0000000000000001", ipaddr.IPv4Network("140.182.0.0/16"), 500000000, 0)
         self.api.updatePrefixBW("0000000000000001", ipaddr.IPv4Network("149.159.0.0/16"), 80000000, 0)
         self.api.run_balancers()
         
-        self.assertTrue( len(flows) == 12)
+        self.assertTrue( len(flows) == 8)
+        exit
         flow = flows[0]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 2252603392, 'nw_src_mask': 16})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 167837696, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 600)
         flow = flows[1]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 10, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 10, 'nw_dst': 167837696})
+        self.assertEquals(flow['priority'], 600)
         flow = flows[2]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 2252603392, 'nw_src_mask': 16})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 167837696, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 600)
         flow = flows[3]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 9, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 9, 'nw_dst': 167837696})
+        self.assertEquals(flow['priority'], 600)
         flow = flows[4]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': '4'}, {'type': 'output', 'port': '3'}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 2252603392, 'nw_src_mask': 17})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 167837696, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 600)
         flow = flows[5]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': 4}, {'type': 'output', 'port': 3}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 17, 'phys_port': 10, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 10, 'nw_dst': 167837696})
+        self.assertEquals(flow['priority'], 600)
         flow = flows[6]
         self.assertEquals(flow['actions'], [{'type': 'output', 'port': '4'}, {'type': 'output', 'port': '3'}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 2252603392, 'nw_src_mask': 17})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 167837696, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 600)
         flow = flows[7]
         self.assertEquals(flow['actions'],[{'type': 'output', 'port': 4}, {'type': 'output', 'port': 3}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 17, 'phys_port': 9, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
-        flow = flows[8]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': '4'}, {'type': 'output', 'port': '3'}])
-        self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 2252636160, 'nw_src_mask': 17})
-        self.assertEquals(flow['priority'], 26850)
-        flow = flows[9]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 4}, {'type': 'output', 'port': 3}])
-        self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 17, 'phys_port': 10, 'nw_dst': 2252636160})
-        self.assertEquals(flow['priority'], 26850)
-        flow = flows[10]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': '4'}, {'type': 'output', 'port': '3'}])
-        self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 2252636160, 'nw_src_mask': 17})
-        self.assertEquals(flow['priority'], 26850)
-        flow = flows[11]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 4}, {'type': 'output', 'port': 3}])
-        self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 17, 'phys_port': 9, 'nw_dst': 2252636160})
-        self.assertEquals(flow['priority'], 26850)
-
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 9, 'nw_dst': 167837696})
+        self.assertEquals(flow['priority'], 600)
 
         #run the balancer again!
         flows = []
         self.api.run_balancers()
         print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
-        self.assertTrue(len(flows) == 12)
-
+        self.assertTrue(len(flows) == 8)
         #run the balancer again!
         flows = []
         self.api.run_balancers()
@@ -233,73 +211,43 @@ class BalancerInitTest(unittest.TestCase):
         flow = flows[0]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 2252603392, 'nw_src_mask': 18})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 168099840, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 1000)
         flow = flows[1]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 18, 'phys_port': 10, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 10, 'nw_dst': 168099840})
+        self.assertEquals(flow['priority'], 1000)
         flow = flows[2]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 2252603392, 'nw_src_mask': 18})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 168099840, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 1000)
         flow = flows[3]
         self.assertEquals(flow['actions'],[])
         self.assertEquals(flow['command'],"DELETE_STRICT")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 18, 'phys_port': 9, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 9, 'nw_dst': 168099840})
+        self.assertEquals(flow['priority'], 1000)
         flow = flows[4]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': '1'}, {'type': 'output', 'port': '2'}])
+        self.assertEquals(flow['actions'],[{'type': 'output', 'port': '4'}, {'type': 'output', 'port': '3'}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 2252603392, 'nw_src_mask': 18})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 10, 'nw_src': 168099840, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 1000)
         flow = flows[5]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 1}, {'type': 'output', 'port': 2}])
+        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 4}, {'type': 'output', 'port': 3}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 18, 'phys_port': 10, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 10, 'nw_dst': 168099840})
+        self.assertEquals(flow['priority'], 1000)
         flow = flows[6]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': '1'}, {'type': 'output', 'port': '2'}])
+        self.assertEquals(flow['actions'],[{'type': 'output', 'port': '4'}, {'type': 'output', 'port': '3'}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 2252603392, 'nw_src_mask': 18})
-        self.assertEquals(flow['priority'], 26800)
+        self.assertEquals(flow['header'], {'phys_port': 9, 'nw_src': 168099840, 'nw_src_mask': 16})
+        self.assertEquals(flow['priority'], 1000)
         flow = flows[7]
-        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 1}, {'type': 'output', 'port': 2}])
+        self.assertEquals(flow['actions'],[{'type': 'output', 'port': 4}, {'type': 'output', 'port': 3}])
         self.assertEquals(flow['command'],"ADD")
-        self.assertEquals(flow['header'], {'nw_dst_mask': 18, 'phys_port': 9, 'nw_dst': 2252603392})
-        self.assertEquals(flow['priority'], 26800)
-
-        #run the balancer again!
-        flows = []
-        self.api.run_balancers()
-        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
-        self.assertTrue(len(flows) == 8)
-
-        #run the balancer again!
-        flows = []
-        self.api.run_balancers()
-        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
-        self.assertTrue(len(flows) == 12)
-
-        #run the balancer again!
-        flows = []
-        self.api.run_balancers()
-        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
-        self.assertTrue(len(flows) == 12)
-
-        #run the balancer again!
-        flows = []
-        self.api.run_balancers()
-        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
-        self.assertTrue(len(flows) == 12)
-
-        #run the balancer again!
-        flows = []
-        self.api.run_balancers()
-        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
-        self.assertTrue(len(flows) == 12)
+        self.assertEquals(flow['header'], {'nw_dst_mask': 16, 'phys_port': 9, 'nw_dst': 168099840})
+        self.assertEquals(flow['priority'], 1000)
 
         #run the balancer again!
         flows = []
@@ -317,9 +265,31 @@ class BalancerInitTest(unittest.TestCase):
         flows = []
         self.api.run_balancers()
         print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
-        self.assertTrue(len(flows) == 0)
+        self.assertTrue(len(flows) == 8)
 
-        #ok its balananced!!!!
+        #run the balancer again!
+        flows = []
+        self.api.run_balancers()
+        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
+        self.assertTrue(len(flows) == 8)
+
+        #run the balancer again!
+        flows = []
+        self.api.run_balancers()
+        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
+        self.assertTrue(len(flows) == 8)
+
+        #run the balancer again!
+        flows = []
+        self.api.run_balancers()
+        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
+        self.assertTrue(len(flows) == 8)
+
+        #run the balancer again!
+        flows = []
+        self.api.run_balancers()
+        print "\n FLOWS AFTER BALANCE: %d \n" % len(flows)
+        self.assertTrue(len(flows) == 8)
 
 def suite():
     suite = unittest.TestLoader().loadTestsFromTestCase(BalancerInitTest)


### PR DESCRIPTION
The IU deployment has had a few issues.  First our switch is unable to handle a large number of flows.  So when we have all prefixes on all interfaces it quickly explodes past the total number of flows we can handle.  A SimpleBalancer mode was implemented so that we can ignore the in_port for all flows.

Next we improved the balancer, it was getting stuck on a max-len we essentially stopped balancing.  The algorithm accounts for this as best as it can by moving everything it can off of the highest loaded sensor.  When there is only 1 prefix remaining it then ignores that sensor from balancing until the prefix load drops to where it can accept additional prefixes.